### PR TITLE
Move to loadable state

### DIFF
--- a/lib/hammer_cli_foreman_puppet.rb
+++ b/lib/hammer_cli_foreman_puppet.rb
@@ -8,45 +8,42 @@ module HammerCLIForemanPuppet
   require 'hammer_cli_foreman_puppet/option_sources'
   require 'hammer_cli_foreman_puppet/associating_commands'
 
-  require 'hammer_cli_foreman_puppet/organization_extenstions'
-  require 'hammer_cli_foreman_puppet/location_extenstions'
-
-  require 'hammer_cli_foreman_puppet/classes'
+  # Puppet commands
+  require 'hammer_cli_foreman_puppet/smart_class_parameter'
   require 'hammer_cli_foreman_puppet/environment'
   require 'hammer_cli_foreman_puppet/config_group'
-  require 'hammer_cli_foreman_puppet/smart_class_parameter'
+  require 'hammer_cli_foreman_puppet/class'
 
-
-  HammerCLI::MainCommand.lazy_subcommand(
-    'classes',
-    _('Manage Foreman Puppet Classes'),
-    'HammerCLIForemanPuppet::PuppetClass',
-    'hammer_cli_foreman_puppet/class'
-  )
-  HammerCLI::MainCommand.lazy_subcommand(
-    'environment',
-    _('Manage Foreman puppet environments'),
-    'HammerCLIForemanPuppet::PuppetEnvironment',
-    'hammer_cli_foreman_puppet/environment'
-  )
-  HammerCLI::MainCommand.lazy_subcommand(
-    'config-group',
-    _('Manage Foreman config groups'),
-    'HammerCLIForemanPuppet::ConfigGroup',
-    'hammer_cli_foreman_puppet/config_group'
-  )
-  HammerCLI::MainCommand.lazy_subcommand(
-    'smart-class-paramaters',
-    _('Manage Foreman puppet smart class paramteters'),
-    'HammerCLIForemanPuppet::SmartClassParameter',
-    'hammer_cli_foreman_puppet/smart_class_parameter'
-  )
-  # subcommands to hammer_cli_foreman commands
+  # extensions to hammer_cli_foreman commands
   require 'hammer_cli_foreman_puppet/host'
   require 'hammer_cli_foreman_puppet/organization'
   require 'hammer_cli_foreman_puppet/location'
   require 'hammer_cli_foreman_puppet/smart_proxy'
   require 'hammer_cli_foreman_puppet/combination'
   require 'hammer_cli_foreman_puppet/hostgroup'
-end
 
+  HammerCLI::MainCommand.lazy_subcommand(
+    'pp_puppet-class',
+    _('Manage Foreman Puppet classes'),
+    'HammerCLIForemanPuppet::PuppetClass',
+    'hammer_cli_foreman_puppet/class'
+  )
+  HammerCLI::MainCommand.lazy_subcommand(
+    'pp_puppet-environment',
+    _('Manage Foreman Puppet environments'),
+    'HammerCLIForemanPuppet::PuppetEnvironment',
+    'hammer_cli_foreman_puppet/environment'
+  )
+  HammerCLI::MainCommand.lazy_subcommand(
+    'pp_config-group',
+    _('Manage Foreman config groups'),
+    'HammerCLIForemanPuppet::ConfigGroup',
+    'hammer_cli_foreman_puppet/config_group'
+  )
+  HammerCLI::MainCommand.lazy_subcommand(
+    'pp_sc-param',
+    _('Manage Foreman Puppet smart class parameters'),
+    'HammerCLIForemanPuppet::SmartClassParameter',
+    'hammer_cli_foreman_puppet/smart_class_parameter'
+  )
+end

--- a/lib/hammer_cli_foreman_puppet/associating_commands/associating_commands.rb
+++ b/lib/hammer_cli_foreman_puppet/associating_commands/associating_commands.rb
@@ -2,11 +2,12 @@
 module HammerCLIForemanPuppet
   module AssociatingCommands
     module PuppetEnvironment
-      extend CommandExtension
+      extend HammerCLIForeman::AssociatingCommands::CommandExtension
 
-      class AddPuppetEnvironmentCommand < HammerCLIForeman::AddAssociatedCommand
+      class AddPuppetEnvironmentCommandPuppet < HammerCLIForeman::AddAssociatedCommand
         associated_resource :environments
         desc _('Associate a Puppet environment')
+        command_name "puppet_add-environment"
 
         success_message _("The environment has been associated.")
         failure_message _("Could not associate the environment")
@@ -14,9 +15,10 @@ module HammerCLIForemanPuppet
         extend_with(HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new)
       end
 
-      class RemovePuppetEnvironmentCommand < HammerCLIForeman::RemoveAssociatedCommand
+      class RemovePuppetEnvironmentCommandPuppet < HammerCLIForeman::RemoveAssociatedCommand
         associated_resource :environments
         desc _('Disassociate a Puppet environment')
+        command_name "puppet_remove-environment"
 
         success_message _("The environment has been disassociated.")
         failure_message _("Could not disassociate the environment")

--- a/lib/hammer_cli_foreman_puppet/class.rb
+++ b/lib/hammer_cli_foreman_puppet/class.rb
@@ -40,7 +40,7 @@ module HammerCLIForemanPuppet
     end
 
 
-    class SCParamsCommand < HammerCLIForeman::SmartClassParametersBriefList
+    class SCParamsCommand < HammerCLIForemanPuppet::SmartClassParametersBriefList
       build_options_for :puppetclasses
 
       def validate_options

--- a/lib/hammer_cli_foreman_puppet/command_extensions/environment.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/environment.rb
@@ -2,7 +2,7 @@ module HammerCLIForemanPuppet
   module CommandExtensions
     class PuppetEnvironment < HammerCLI::CommandExtensions
       # Remove when support of --environment options is ended.
-      base.option_family(
+      option_family(
         aliased_resource: 'environment',
         description: _('Puppet environment'),
         deprecation: _("Use %s instead") % '--puppet-environment[-id]',

--- a/lib/hammer_cli_foreman_puppet/command_extensions/environments.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/environments.rb
@@ -2,7 +2,7 @@ module HammerCLIForemanPuppet
   module CommandExtensions
     class PuppetEnvironments < HammerCLI::CommandExtensions
       # Remove when support of --environments options is ended.
-      base.option_family(
+      option_family(
         aliased_resource: 'environment',
         description: _('Puppet environments'),
         deprecation: _("Use %s instead") % '--puppet-environment[s|-ids]',

--- a/lib/hammer_cli_foreman_puppet/host.rb
+++ b/lib/hammer_cli_foreman_puppet/host.rb
@@ -1,18 +1,17 @@
-require 'hammer_cli_foreman_puppet/puppet_class'
+require 'hammer_cli_foreman_puppet/class'
 require 'hammer_cli_foreman/host'
 
 module HammerCLIForemanPuppet
-
   class PuppetClassesCommand < HammerCLIForeman::ListCommand
     command_name "puppet-classes"
     resource :puppetclasses
 
     output HammerCLIForemanPuppet::PuppetClass::ListCommand.output_definition
- 
+
     def send_request
         HammerCLIForemanPuppet::PuppetClass::ListCommand.unhash_classes(super)
     end
-  
+
     build_options do |o|
       o.without(:hostgroup_id, :environment_id)
       o.expand.only(:hosts)
@@ -21,17 +20,17 @@ module HammerCLIForemanPuppet
 
   class InfoCommand < HammerCLIForeman::InfoCommand
     output do
-      field nil, _("Puppet Environment"), HammerCLIForeman::Fields::SingleReference, :key => :environment
-      field nil, _("Puppet CA Proxy"), HammerCLIForeman::Fields::SingleReference, :key => :puppet_ca_proxy
-      field nil, _("Puppet Master Proxy"), HammerCLIForeman::Fields::SingleReference, :key => :puppet_proxy
+      field nil, _("PP Puppet Environment"), Fields::SingleReference, :key => :environment
+      field nil, _("PP Puppet CA Proxy"), Fields::SingleReference, :key => :puppet_ca_proxy
+      field nil, _("PP Puppet Master Proxy"), Fields::SingleReference, :key => :puppet_proxy
     end
   end
 
   HammerCLIForeman::Host.subcommand 'puppetclass',
                                      HammerCLIForemanPuppet::PuppetClassesCommand.desc,
                                      HammerCLIForemanPuppet::PuppetClassesCommand
-  
- HammerCLIForeman::Host::InfoCommand.subcommand 'puppet-info',
+
+  HammerCLIForeman::Host::InfoCommand.subcommand 'puppet-info',
                                     HammerCLIForemanPuppet::InfoCommand.desc,
                                     HammerCLIForemanPuppet::InfoCommand
 
@@ -41,7 +40,7 @@ module HammerCLIForemanPuppet
   HammerCLIForeman::Host::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
   )
-  HammerCLIForeman::Host::CommonUpdateOptions.extend_with(
-    HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
-  )
+  #HammerCLIForeman::Host::CommonUpdateOptions.extend_with(
+  #  HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
+  #)
 end

--- a/lib/hammer_cli_foreman_puppet/organization.rb
+++ b/lib/hammer_cli_foreman_puppet/organization.rb
@@ -4,7 +4,7 @@ module HammerCLIForemanPuppet
   HammerCLIForeman::Organization::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
-  HammerCLIForeman::Organization::CreateCommand.extend_with(
+  HammerCLIForeman::Organization::UpdateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
   #TODO: verify


### PR DESCRIPTION
* Fix typos
* Comment non-compiling code
* Rename hammer commands such that they can co-exist with the hammer-cli-foreman commands from master for now (to pp* or PP*)
* Basic commands available (puppet_sc-param, puppet_environment, puppet_config-group, puppet_class) 
* Works with hammer-cli-foreman master and https://github.com/amirfefer/hammer-cli-foreman/pull/1