### PR TITLE
Include second level commands

### DIFF
--- a/lib/hammer_cli_foreman_puppet.rb
+++ b/lib/hammer_cli_foreman_puppet.rb
@@ -8,24 +8,29 @@ module HammerCLIForemanPuppet
   require 'hammer_cli_foreman_puppet/option_sources'
   require 'hammer_cli_foreman_puppet/associating_commands'
 
-  require 'hammer_cli_foreman_puppet/organization_extenstions'
-  require 'hammer_cli_foreman_puppet/location_extenstions'
-
-  require 'hammer_cli_foreman_puppet/classes'
+  # Puppet commands
+  require 'hammer_cli_foreman_puppet/smart_class_parameter'
   require 'hammer_cli_foreman_puppet/environment'
   require 'hammer_cli_foreman_puppet/config_group'
-  require 'hammer_cli_foreman_puppet/smart_class_parameter'
+  require 'hammer_cli_foreman_puppet/class'
 
+  # extensions to hammer_cli_foreman commands
+  require 'hammer_cli_foreman_puppet/host'
+  require 'hammer_cli_foreman_puppet/organization'
+  require 'hammer_cli_foreman_puppet/location'
+  require 'hammer_cli_foreman_puppet/smart_proxy'
+  require 'hammer_cli_foreman_puppet/combination'
+  require 'hammer_cli_foreman_puppet/hostgroup'
 
   HammerCLI::MainCommand.lazy_subcommand(
-    'classes',
-    _('Manage Foreman Puppet Classes'),
+    'puppet-class',
+    _('Manage Foreman Puppet classes'),
     'HammerCLIForemanPuppet::PuppetClass',
     'hammer_cli_foreman_puppet/class'
   )
   HammerCLI::MainCommand.lazy_subcommand(
-    'environment',
-    _('Manage Foreman puppet environments'),
+    'puppet-environment',
+    _('Manage Foreman Puppet environments'),
     'HammerCLIForemanPuppet::PuppetEnvironment',
     'hammer_cli_foreman_puppet/environment'
   )
@@ -36,17 +41,9 @@ module HammerCLIForemanPuppet
     'hammer_cli_foreman_puppet/config_group'
   )
   HammerCLI::MainCommand.lazy_subcommand(
-    'smart-class-paramaters',
-    _('Manage Foreman puppet smart class paramteters'),
+    'sc-param',
+    _('Manage Foreman Puppet smart class parameters'),
     'HammerCLIForemanPuppet::SmartClassParameter',
     'hammer_cli_foreman_puppet/smart_class_parameter'
   )
-  # subcommands to hammer_cli_foreman commands
-  require 'hammer_cli_foreman_puppet/host'
-  require 'hammer_cli_foreman_puppet/organization'
-  require 'hammer_cli_foreman_puppet/location'
-  require 'hammer_cli_foreman_puppet/smart_proxy'
-  require 'hammer_cli_foreman_puppet/combination'
-  require 'hammer_cli_foreman_puppet/hostgroup'
 end
-

--- a/lib/hammer_cli_foreman_puppet/associating_commands/associating_commands.rb
+++ b/lib/hammer_cli_foreman_puppet/associating_commands/associating_commands.rb
@@ -1,4 +1,3 @@
-
 module HammerCLIForemanPuppet
   module AssociatingCommands
     module PuppetEnvironment

--- a/lib/hammer_cli_foreman_puppet/associating_commands/associating_commands.rb
+++ b/lib/hammer_cli_foreman_puppet/associating_commands/associating_commands.rb
@@ -2,11 +2,12 @@
 module HammerCLIForemanPuppet
   module AssociatingCommands
     module PuppetEnvironment
-      extend CommandExtension
+      extend HammerCLIForeman::AssociatingCommands::CommandExtension
 
       class AddPuppetEnvironmentCommand < HammerCLIForeman::AddAssociatedCommand
         associated_resource :environments
         desc _('Associate a Puppet environment')
+        command_name "add-environment"
 
         success_message _("The environment has been associated.")
         failure_message _("Could not associate the environment")
@@ -17,6 +18,7 @@ module HammerCLIForemanPuppet
       class RemovePuppetEnvironmentCommand < HammerCLIForeman::RemoveAssociatedCommand
         associated_resource :environments
         desc _('Disassociate a Puppet environment')
+        command_name "remove-environment"
 
         success_message _("The environment has been disassociated.")
         failure_message _("Could not disassociate the environment")

--- a/lib/hammer_cli_foreman_puppet/class.rb
+++ b/lib/hammer_cli_foreman_puppet/class.rb
@@ -40,7 +40,7 @@ module HammerCLIForemanPuppet
     end
 
 
-    class SCParamsCommand < HammerCLIForeman::SmartClassParametersBriefList
+    class SCParamsCommand < HammerCLIForemanPuppet::SmartClassParametersBriefList
       build_options_for :puppetclasses
 
       def validate_options

--- a/lib/hammer_cli_foreman_puppet/command_extensions/environment.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/environment.rb
@@ -2,7 +2,7 @@ module HammerCLIForemanPuppet
   module CommandExtensions
     class PuppetEnvironment < HammerCLI::CommandExtensions
       # Remove when support of --environment options is ended.
-      base.option_family(
+      option_family(
         aliased_resource: 'environment',
         description: _('Puppet environment'),
         deprecation: _("Use %s instead") % '--puppet-environment[-id]',

--- a/lib/hammer_cli_foreman_puppet/command_extensions/environment.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/environment.rb
@@ -1,21 +1,6 @@
 module HammerCLIForemanPuppet
   module CommandExtensions
     class PuppetEnvironment < HammerCLI::CommandExtensions
-      # Remove when support of --environment options is ended.
-      option_family(
-        aliased_resource: 'environment',
-        description: _('Puppet environment'),
-        deprecation: _("Use %s instead") % '--puppet-environment[-id]',
-        deprecated: { '--environment' => _("Use %s instead") % '--puppet-environment[-id]',
-                      '--environment-id' => _("Use %s instead") % '--puppet-environment[-id]'}
-      ) do
-        parent '--environment-id', 'ENVIRONMENT_ID', _(''),
-               format: HammerCLI::Options::Normalizers::Number.new,
-               attribute_name: :option_environment_id
-        child '--environment', 'ENVIRONMENT_NAME', _('Environment name'),
-              attribute_name: :option_environment_name
-      end
-
       option_sources do |sources, command|
         sources.find_by_name('IdResolution').insert_relative(
           :after,

--- a/lib/hammer_cli_foreman_puppet/command_extensions/environments.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/environments.rb
@@ -1,21 +1,6 @@
 module HammerCLIForemanPuppet
   module CommandExtensions
     class PuppetEnvironments < HammerCLI::CommandExtensions
-      # Remove when support of --environments options is ended.
-      option_family(
-        aliased_resource: 'environment',
-        description: _('Puppet environments'),
-        deprecation: _("Use %s instead") % '--puppet-environment[s|-ids]',
-        deprecated: { '--environments' => _("Use %s instead") % '--puppet-environment[s|-ids]',
-                      '--environment-ids' => _("Use %s instead") % '--puppet-environment[s|-ids]' }
-      ) do
-        parent '--environment-ids', 'ENVIRONMENT_IDS', _('Environment IDs'),
-               format: HammerCLI::Options::Normalizers::List.new,
-               attribute_name: :option_environment_ids
-        child '--environments', 'ENVIRONMENT_NAMES', _(''),
-              attribute_name: :option_environment_names
-      end
-
       option_sources do |sources, command|
         sources.find_by_name('IdResolution').insert_relative(
           :after,

--- a/lib/hammer_cli_foreman_puppet/command_extensions/environments.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/environments.rb
@@ -2,7 +2,7 @@ module HammerCLIForemanPuppet
   module CommandExtensions
     class PuppetEnvironments < HammerCLI::CommandExtensions
       # Remove when support of --environments options is ended.
-      base.option_family(
+      option_family(
         aliased_resource: 'environment',
         description: _('Puppet environments'),
         deprecation: _("Use %s instead") % '--puppet-environment[s|-ids]',

--- a/lib/hammer_cli_foreman_puppet/command_extensions/host.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/host.rb
@@ -1,0 +1,9 @@
+module HammerCLIForemanPuppet
+  module CommandExtensions
+    class Host < HammerCLI::CommandExtensions
+      output do |definition|
+        definition.insert(:after, :location, HammerCLIForemanPuppet::Host::InfoCommand.output_definition.fields)
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman_puppet/command_extensions/hostgroup.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/hostgroup.rb
@@ -1,0 +1,15 @@
+module HammerCLIForemanPuppet
+  module CommandExtensions
+    class HostgroupInfo < HammerCLI::CommandExtensions
+      output do |definition|
+        definition.insert(:after, :compute_resource, HammerCLIForemanPuppet::Hostgroup::InfoCommand.output_definition.fields)
+      end
+    end
+
+    class HostgroupList < HammerCLI::CommandExtensions
+      output do |definition|
+        definition.insert(:after, :operatingsystem, HammerCLIForemanPuppet::Hostgroup::ListCommand.output_definition.fields)
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman_puppet/command_extensions/location.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/location.rb
@@ -1,0 +1,9 @@
+module HammerCLIForemanPuppet
+  module CommandExtensions
+    class LocationInfo < HammerCLI::CommandExtensions
+      output do |definition|
+        definition.insert(:after, :realms, HammerCLIForemanPuppet::Location::InfoCommand.output_definition.fields)
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman_puppet/command_extensions/organization.rb
+++ b/lib/hammer_cli_foreman_puppet/command_extensions/organization.rb
@@ -1,0 +1,9 @@
+module HammerCLIForemanPuppet
+  module CommandExtensions
+    class OrganizationInfo < HammerCLI::CommandExtensions
+      output do |definition|
+        definition.insert(:after, :realms, HammerCLIForemanPuppet::Organization::InfoCommand.output_definition.fields)
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman_puppet/host.rb
+++ b/lib/hammer_cli_foreman_puppet/host.rb
@@ -1,18 +1,17 @@
-require 'hammer_cli_foreman_puppet/puppet_class'
+require 'hammer_cli_foreman_puppet/class'
 require 'hammer_cli_foreman/host'
 
 module HammerCLIForemanPuppet
-
   class PuppetClassesCommand < HammerCLIForeman::ListCommand
     command_name "puppet-classes"
     resource :puppetclasses
 
     output HammerCLIForemanPuppet::PuppetClass::ListCommand.output_definition
- 
+
     def send_request
         HammerCLIForemanPuppet::PuppetClass::ListCommand.unhash_classes(super)
     end
-  
+
     build_options do |o|
       o.without(:hostgroup_id, :environment_id)
       o.expand.only(:hosts)
@@ -21,17 +20,17 @@ module HammerCLIForemanPuppet
 
   class InfoCommand < HammerCLIForeman::InfoCommand
     output do
-      field nil, _("Puppet Environment"), HammerCLIForeman::Fields::SingleReference, :key => :environment
-      field nil, _("Puppet CA Proxy"), HammerCLIForeman::Fields::SingleReference, :key => :puppet_ca_proxy
-      field nil, _("Puppet Master Proxy"), HammerCLIForeman::Fields::SingleReference, :key => :puppet_proxy
+      field nil, _("Puppet Environment"), Fields::SingleReference, :key => :environment
+      field nil, _("Puppet CA Proxy"), Fields::SingleReference, :key => :puppet_ca_proxy
+      field nil, _("Puppet Master Proxy"), Fields::SingleReference, :key => :puppet_proxy
     end
   end
 
   HammerCLIForeman::Host.subcommand 'puppetclass',
                                      HammerCLIForemanPuppet::PuppetClassesCommand.desc,
                                      HammerCLIForemanPuppet::PuppetClassesCommand
-  
- HammerCLIForeman::Host::InfoCommand.subcommand 'puppet-info',
+
+  HammerCLIForeman::Host::InfoCommand.subcommand 'puppet-info',
                                     HammerCLIForemanPuppet::InfoCommand.desc,
                                     HammerCLIForemanPuppet::InfoCommand
 
@@ -41,7 +40,7 @@ module HammerCLIForemanPuppet
   HammerCLIForeman::Host::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
   )
-  HammerCLIForeman::Host::CommonUpdateOptions.extend_with(
-    HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
-  )
+  #HammerCLIForeman::Host::CommonUpdateOptions.extend_with(
+  #  HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
+  #)
 end

--- a/lib/hammer_cli_foreman_puppet/host.rb
+++ b/lib/hammer_cli_foreman_puppet/host.rb
@@ -1,38 +1,92 @@
 require 'hammer_cli_foreman_puppet/class'
-require 'hammer_cli_foreman/host'
+require 'hammer_cli_foreman_puppet/host'
+require 'hammer_cli_foreman_puppet/command_extensions/host'
 
 module HammerCLIForemanPuppet
-  class PuppetClassesCommand < HammerCLIForeman::ListCommand
-    command_name "puppet-classes"
-    resource :puppetclasses
 
-    output HammerCLIForemanPuppet::PuppetClass::ListCommand.output_definition
+  module CommonUpdateOptions
+    def self.included(base)
+      base.option '--puppet-proxy', 'PUPPET_PROXY_NAME', '',
+                  referenced_resource: 'puppet_proxy',
+                  aliased_resource: 'puppet_proxy'
+      base.option '--puppet-ca-proxy', 'PUPPET_CA_PROXY_NAME', '',
+                  referenced_resource: 'puppet_ca_proxy',
+                  aliased_resource: 'puppet_ca_proxy'
+      base.option_family(
+        format: HammerCLI::Options::Normalizers::List.new,
+        aliased_resource: 'puppet-class',
+        description: 'Names/Ids of associated puppet classes'
+      ) do
+        parent '--puppet-class-ids', 'PUPPET_CLASS_IDS', '',
+               attribute_name: :option_puppetclass_ids
+        child '--puppet-classes', 'PUPPET_CLASS_NAMES', '',
+               attribute_name: :option_puppetclass_names
+      end
+      base.build_options :without => [
+           :puppet_class_ids]
+    end
 
-    def send_request
+    def request_params
+      puppet_proxy_id = proxy_id(option_puppet_proxy)
+      params['host']['puppet_proxy_id'] ||= puppet_proxy_id unless puppet_proxy_id.nil?
+
+      puppet_ca_proxy_id = proxy_id(option_puppet_ca_proxy)
+      params['host']['puppet_ca_proxy_id'] ||= puppet_ca_proxy_id unless puppet_ca_proxy_id.nil?
+    end
+  end
+
+  class Host < HammerCLIForeman::Command
+
+    class PuppetClassesCommand < HammerCLIForeman::ListCommand
+      command_name "puppet-classes"
+      resource :puppetclasses
+
+      output HammerCLIForemanPuppet::PuppetClass::ListCommand.output_definition
+
+      def send_request
         HammerCLIForemanPuppet::PuppetClass::ListCommand.unhash_classes(super)
+      end
+
+      build_options do |o|
+        o.without(:hostgroup_id, :environment_id)
+        o.expand.only(:hosts)
+      end
     end
 
-    build_options do |o|
-      o.without(:hostgroup_id, :environment_id)
-      o.expand.only(:hosts)
+    class SCParamsCommand < HammerCLIForemanPuppet::SmartClassParametersList
+      build_options_for :hosts
+      command_name "sc-params"
+
+      def validate_options
+        super
+        validator.any(:option_host_name, :option_host_id).required
+      end
+    end
+
+    class InfoCommand < HammerCLIForeman::InfoCommand
+      output do
+        field nil, _("Puppet Environment"), Fields::SingleReference, :key => :environment
+        field nil, _("Puppet CA Proxy"), Fields::SingleReference, :key => :puppet_ca_proxy
+        field nil, _("Puppet Master Proxy"), Fields::SingleReference, :key => :puppet_proxy
+      end
     end
   end
 
-  class InfoCommand < HammerCLIForeman::InfoCommand
-    output do
-      field nil, _("Puppet Environment"), Fields::SingleReference, :key => :environment
-      field nil, _("Puppet CA Proxy"), Fields::SingleReference, :key => :puppet_ca_proxy
-      field nil, _("Puppet Master Proxy"), Fields::SingleReference, :key => :puppet_proxy
-    end
+  ::HammerCLIForeman::Host::CreateCommand.instance_eval do
+    include HammerCLIForemanPuppet::CommonUpdateOptions
   end
 
-  HammerCLIForeman::Host.subcommand 'puppetclass',
-                                     HammerCLIForemanPuppet::PuppetClassesCommand.desc,
-                                     HammerCLIForemanPuppet::PuppetClassesCommand
+  ::HammerCLIForeman::Host::UpdateCommand.instance_eval do
+    include HammerCLIForemanPuppet::CommonUpdateOptions
+  end
 
-  HammerCLIForeman::Host::InfoCommand.subcommand 'puppet-info',
-                                    HammerCLIForemanPuppet::InfoCommand.desc,
-                                    HammerCLIForemanPuppet::InfoCommand
+  HammerCLIForeman::Host.subcommand 'puppet-classes',
+                                     HammerCLIForemanPuppet::Host::PuppetClassesCommand.desc,
+                                     HammerCLIForemanPuppet::Host::PuppetClassesCommand
+
+  HammerCLIForeman::Host.subcommand 'sc-params',
+                                     HammerCLIForemanPuppet::Host::SCParamsCommand.desc,
+                                     HammerCLIForemanPuppet::Host::SCParamsCommand
 
   HammerCLIForeman::Host::ListCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
@@ -40,7 +94,7 @@ module HammerCLIForemanPuppet
   HammerCLIForeman::Host::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
   )
-  #HammerCLIForeman::Host::CommonUpdateOptions.extend_with(
-  #  HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
-  #)
+  HammerCLIForeman::Host::InfoCommand.extend_with(
+    HammerCLIForemanPuppet::CommandExtensions::Host.new
+  )
 end

--- a/lib/hammer_cli_foreman_puppet/hostgroup.rb
+++ b/lib/hammer_cli_foreman_puppet/hostgroup.rb
@@ -1,26 +1,85 @@
-
 require 'hammer_cli_foreman/hostgroup'
+require 'hammer_cli_foreman_puppet/references'
+require 'hammer_cli_foreman_puppet/command_extensions/hostgroup.rb'
 
 module HammerCLIForemanPuppet
-  class PuppetClassesCommand < HammerCLIForeman::ListCommand
-    command_name "puppet-classes"
-    resource :puppetclasses
 
-    output HammerCLIForemanPuppet::PuppetClass::ListCommand.output_definition
-
-    def send_request
-        HammerCLIForemanPuppet::PuppetClass::ListCommand.unhash_classes(super)
+  module HostgroupUpdateCreatePuppetOptions
+    def self.included(base)
+      base.option "--puppet-class-ids", "PUPPETCLASS_IDS", _("List of puppetclass ids"),
+        :format => HammerCLI::Options::Normalizers::List.new,
+        :attribute_name => :option_puppetclass_ids
+      base.option "--puppet-classes", "PUPPET_CLASS_NAMES", "",
+        :format => HammerCLI::Options::Normalizers::List.new,
+        :attribute_name => :option_puppetclass_names
+      base.option "--puppet-ca-proxy", "PUPPET_CA_PROXY_NAME", _("Name of puppet CA proxy")
+      base.option "--puppet-proxy", "PUPPET_PROXY_NAME",  _("Name of puppet proxy")
     end
 
-    build_options do |o|
-      o.without(:host_id, :environment_id)
-      o.expand.only(:hostgroups)
+    def request_params
+      params['hostgroup']["puppet_proxy_id"] ||= proxy_id(option_puppet_proxy) if option_puppet_proxy
+      params['hostgroup']["puppet_ca_proxy_id"] ||= proxy_id(option_puppet_ca_proxy) if option_puppet_ca_proxy
     end
   end
 
-  HammerCLIForeman::Hostgroup.subcommand 'puppetclass',
-                                           HammerCLIForemanPuppet::PuppetClassesCommand.desc,
-                                           HammerCLIForemanPuppet::PuppetClassesCommand
+  class Hostgroup < HammerCLIForeman::Command
+
+    class PuppetClassesCommand < HammerCLIForeman::ListCommand
+      command_name "puppet-classes"
+      resource :puppetclasses
+
+      output HammerCLIForemanPuppet::PuppetClass::ListCommand.output_definition
+
+      def send_request
+        HammerCLIForemanPuppet::PuppetClass::ListCommand.unhash_classes(super)
+      end
+
+      build_options do |o|
+        o.without(:host_id, :environment_id)
+        o.expand.only(:hostgroups)
+      end
+    end
+
+    class PuppetSCParamsCommand < HammerCLIForemanPuppet::SmartClassParametersList
+      build_options_for :hostgroups
+      command_name "sc-params"
+
+      def validate_options
+        super
+        validator.any(:option_hostgroup_name, :option_hostgroup_id).required
+      end
+    end
+
+    class ListCommand < HammerCLIForeman::InfoCommand
+      output do
+        field nil, _("Puppet Environment"), Fields::SingleReference, :key => :environment
+      end
+    end
+
+    class InfoCommand < HammerCLIForeman::InfoCommand
+      output do
+        field nil, _("Puppet Environment"), Fields::SingleReference, :key => :environment
+        field nil, _("Puppet CA Proxy"), Fields::SingleReference, :key => :puppet_ca_proxy
+        field nil, _("Puppet Master Proxy"), Fields::SingleReference, :key => :puppet_proxy
+        HammerCLIForemanPuppet::References.puppetclasses(self)
+      end
+    end
+  end
+
+  ::HammerCLIForeman::Hostgroup::CreateCommand.instance_eval do
+    include HammerCLIForemanPuppet::HostgroupUpdateCreatePuppetOptions
+  end
+  ::HammerCLIForeman::Hostgroup::UpdateCommand.instance_eval do
+    include HammerCLIForemanPuppet::HostgroupUpdateCreatePuppetOptions
+  end
+
+  HammerCLIForeman::Hostgroup.subcommand 'puppet-classes',
+                                          HammerCLIForemanPuppet::Hostgroup::PuppetClassesCommand.desc,
+                                          HammerCLIForemanPuppet::Hostgroup::PuppetClassesCommand
+
+  HammerCLIForeman::Hostgroup.subcommand 'sc-params',
+                                          HammerCLIForemanPuppet::Hostgroup::PuppetSCParamsCommand.desc,
+                                          HammerCLIForemanPuppet::Hostgroup::PuppetSCParamsCommand
 
   HammerCLIForeman::Hostgroup::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
@@ -28,7 +87,12 @@ module HammerCLIForemanPuppet
   HammerCLIForeman::Hostgroup::UpdateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new
   )
-
+  HammerCLIForeman::Hostgroup::InfoCommand.extend_with(
+    HammerCLIForemanPuppet::CommandExtensions::HostgroupInfo.new
+  )
+  HammerCLIForeman::Hostgroup::ListCommand.extend_with(
+    HammerCLIForemanPuppet::CommandExtensions::HostgroupList.new
+  )
 #TODO - adding puppet class options
 #TODO - resolver
 end

--- a/lib/hammer_cli_foreman_puppet/location.rb
+++ b/lib/hammer_cli_foreman_puppet/location.rb
@@ -1,12 +1,26 @@
 require 'hammer_cli_foreman/location'
+require 'hammer_cli_foreman_puppet/references'
+require 'hammer_cli_foreman_puppet/command_extensions/location'
 
 module HammerCLIForemanPuppet
+  class Location < HammerCLIForeman::Command
+    class InfoCommand < HammerCLIForeman::InfoCommand
+      output do
+        HammerCLIForemanPuppet::References.environments(self)
+      end
+    end
+  end
+
   HammerCLIForeman::Location::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
   HammerCLIForeman::Location::UpdateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
+  HammerCLIForeman::Location::InfoCommand.extend_with(
+    HammerCLIForemanPuppet::CommandExtensions::LocationInfo.new
+  )
+
   #TODO - verify
   ::HammerCLIForeman::Location.instance_eval do
     HammerCLIForemanPuppet::AssociatingCommands::PuppetEnvironment.extend_command(self)

--- a/lib/hammer_cli_foreman_puppet/organization.rb
+++ b/lib/hammer_cli_foreman_puppet/organization.rb
@@ -4,7 +4,7 @@ module HammerCLIForemanPuppet
   HammerCLIForeman::Organization::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
-  HammerCLIForeman::Organization::CreateCommand.extend_with(
+  HammerCLIForeman::Organization::UpdateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
   #TODO: verify

--- a/lib/hammer_cli_foreman_puppet/organization.rb
+++ b/lib/hammer_cli_foreman_puppet/organization.rb
@@ -1,12 +1,26 @@
 require 'hammer_cli_foreman/organization'
+require 'hammer_cli_foreman_puppet/references'
+require 'hammer_cli_foreman_puppet/command_extensions/organization'
 
 module HammerCLIForemanPuppet
+  class Organization < HammerCLIForeman::Command
+    class InfoCommand < HammerCLIForeman::InfoCommand
+      output do
+        HammerCLIForemanPuppet::References.environments(self)
+      end
+    end
+  end
+
   HammerCLIForeman::Organization::CreateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
   HammerCLIForeman::Organization::UpdateCommand.extend_with(
     HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironments.new
   )
+  HammerCLIForeman::Organization::InfoCommand.extend_with(
+    HammerCLIForemanPuppet::CommandExtensions::OrganizationInfo.new
+  )
+
   #TODO: verify
   ::HammerCLIForeman::Organization.instance_eval do
     HammerCLIForemanPuppet::AssociatingCommands::PuppetEnvironment.extend_command(self)

--- a/lib/hammer_cli_foreman_puppet/references.rb
+++ b/lib/hammer_cli_foreman_puppet/references.rb
@@ -1,0 +1,22 @@
+module HammerCLIForemanPuppet
+
+  module References
+
+    def self.environments(dsl)
+      dsl.build do
+        collection :environments, _("Environments"), :numbered => false do
+          custom_field Fields::Reference
+        end
+      end
+    end
+
+    def self.puppetclasses(dsl)
+      dsl.build do
+        collection :puppetclasses, _("Puppetclasses"), :numbered => false do
+          custom_field Fields::Reference
+        end
+      end
+    end
+
+  end
+end

--- a/lib/hammer_cli_foreman_puppet/smart_proxy.rb
+++ b/lib/hammer_cli_foreman_puppet/smart_proxy.rb
@@ -4,9 +4,10 @@ module HammerCLIForemanPuppet
   class ImportPuppetClassesCommand < HammerCLIForeman::Command
     action :import_puppetclasses
 
-    command_name  "import-classes"
-
+    command_name "import-classes"
+    desc _("Import Puppet classes from Puppet proxy")
     option "--dryrun", :flag, _("Do not run the import")
+
 
     output do
       field :message, _("Result"), Fields::LongText
@@ -50,7 +51,7 @@ module HammerCLIForemanPuppet
 
     extend_with(HammerCLIForemanPuppet::CommandExtensions::PuppetEnvironment.new)
   end
-  HammerCLIForeman::SmartProxy.subcommand 'import-puppet-classesCommand',
+  HammerCLIForeman::SmartProxy.subcommand 'import-classes',
                                            HammerCLIForemanPuppet::ImportPuppetClassesCommand.desc,
                                            HammerCLIForemanPuppet::ImportPuppetClassesCommand
 end


### PR DESCRIPTION
* Based on PR #1 and #2 (closed)
* first-level commands are puppet-class,  puppet-environment, config-group, sc-param
* second-level commands are used in host, hostgroup, proxy, location and organization
* Include param-options
* Create issue: location association does not work