### PR TITLE
Fix dependency on hammer-foreman

### DIFF
--- a/hammer_cli_foreman_puppet.gemspec
+++ b/hammer_cli_foreman_puppet.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.test_files    = Dir['{test}/**/*']
 
-  spec.add_dependency 'hammer_cli_foreman', '>= 3.0.0-develop', '< 4.0.0'
+  spec.add_dependency 'hammer_cli_foreman', '> 2.6.0', '< 4.0.0'
 end


### PR DESCRIPTION
The prerelease parts are hard because packaging uses different conventions. This works around it.