### PR TITLE
Make simplecov an optional dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ eval_gemfile(dev_gemfile) if File.exist?(dev_gemfile)
 gemspec
 
 group :test do
-  gem 'ci_reporter', '>= 1.6.3', '< 2.0.0', :require => false
   gem 'minitest'
   gem 'minitest-spec-context'
   gem 'mocha'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,14 @@
-require 'simplecov'
-require 'pathname'
-
-SimpleCov.use_merging true
-SimpleCov.start do
-  command_name 'MiniTest'
-  add_filter 'test'
+begin
+  require 'simplecov'
+rescue LoadError
+else
+  SimpleCov.use_merging true
+  SimpleCov.start do
+    command_name 'MiniTest'
+    add_filter 'test'
+  end
+  SimpleCov.root(Pathname.new(__dir__) + "..")
 end
-SimpleCov.root Pathname.new(File.dirname(__FILE__) + "../../../")
-
 
 require 'minitest/autorun'
 require 'minitest/spec'


### PR DESCRIPTION
It also corrects the root, which was pointing outside of the repository.