### PR TITLE
Fixes #35 - refactor readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,32 @@
-[WIP] hammer_cli_foreman_puppet
-=========================================
+# Hammer CLI Foreman Puppet
 
-This [Hammer CLI](https://github.com/theforeman/hammer-cli) plugin contains
-set of commands for puppet.
-Configuration
--------------
+This Hammer CLI plugin contains a set of commands for [foreman_puppet](https://github.com/theforeman/foreman_puppet), a plugin that adds Puppet functionality to Foreman.
 
-Configuration is expected to be placed in one of hammer's configuration directories for plugins:
-- `/etc/hammer/cli.modules.d/`
-- `~/.hammer/cli.modules.d/`
-- `./.config/cli.modules.d/` (config dir in CWD)
+## Compatibility
 
-If you install `hammer_cli_foreman_puppet` from source you'll have to copy the config file manually
-from `config/foreman_puppet.yml`.
+This is the list of which version of Foreman Puppet and Foreman are needed for which version of this plugin.
 
-License
--------
+|foreman        |foreman_puppet|hammer-cli-puppet |   Notes                                                 |
+|---------------|--------------|----------------- |---------------------------                              |
+| >= 3.0        | ~> 1.0       |  >= 0.0.3        |  Required                                               |
+| <= 2.5        | ~> 0.1       |     -            |  Not supported (functionality is in [hammer-cli-foreman](https://github.com/theforeman/hammer-cli-foreman)) |
 
-This project is licensed under the GPLv3+.
+## Installation
+
+    $ gem install hammer_cli_foreman_puppet
+
+    $ mkdir -p ~/.hammer/cli.modules.d/
+
+    $ cat <<EOQ > ~/.hammer/cli.modules.d/foreman_puppet.yml
+    :foreman_puppet:
+      :enable_module: true
+    EOQ
+
+## Problems
+
+Please feel free to open a [new Github issue](https://github.com/theforeman/hammer-cli-foreman-puppet/issues/new) if you encounter any bugs/issues using this plugin.
+
+## More info
+
+See our [Hammer CLI installation and configuration instuctions](
+https://github.com/theforeman/hammer-cli/blob/master/doc/installation.md#installation).


### PR DESCRIPTION
# Hammer CLI Foreman Puppet

This Hammer CLI plugin contains a set of commands for puppet functionality which added in [foreman_puppet](
  https://github.com/theforeman/foreman_puppet
).

## Compatibility

This is the list of which version of Foreman Puppet and Foreman are needed to which version of this plugin.

|Foreman version|Foreman Puppet|Hammer-puppet  |   Notes                                                 |
|---------------|--------------|---------------|---------------------------                              |
| >= 3.0        | ~> 1.0       |  >= 0.0.3     |  Required                                               |
| <= 2.5        | ~> 0.1       |     -         |  Not supported (functionality is in hammer-cli-foreman) |

## Installation

    $ gem install hammer_cli_foreman_puppet

    $ mkdir -p ~/.hammer/cli.modules.d/

    $ cat <<EOQ > ~/.hammer/cli.modules.d/foreman_puppet.yml
    :foreman_puppet:
      :enable_module: true
    EOQ

## Problems

Please feel free to open a [new Github issue](https://github.com/theforeman/hammer-cli-foreman-puppet/issues/new) if you encounter any bugs/issues using this plugin.

## More info

See our [Hammer CLI installation and configuration instuctions](
https://github.com/theforeman/hammer-cli/blob/master/doc/installation.md#installation).
