### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_puppet.gemspec
+++ b/hammer_cli_foreman_puppet.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['{lib,config}/**/*', 'LICENSE', 'README*'] + Dir["locale/**/*.{po,pot,mo}"]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'hammer_cli_foreman', '> 2.6.0', '< 4.0.0'
+  spec.add_dependency 'hammer_cli_foreman', '> 2.6.0', '< 6.0.0'
 
   spec.required_ruby_version = '>= 2.7', '< 4'
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint to < 6.0.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)