### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/lib/hammer_cli_foreman_puppet/version.rb
+++ b/lib/hammer_cli_foreman_puppet/version.rb
@@ -1,5 +1,5 @@
 module HammerCLIForemanPuppet
   def self.version
-    @version ||= Gem::Version.new '0.1.2'
+    @version ||= Gem::Version.new '0.1.3'
   end
 end


### PR DESCRIPTION
## Summary
- Bump version to 0.1.3 to include the relaxed hammer_cli_foreman dependency from #64
- A new gem release is needed so foreman-packaging can update the vendored gem and unblock foreman-nightly-rpm builds

Generated with [Claude Code](https://claude.com/claude-code)